### PR TITLE
Stop tracking javasqlite

### DIFF
--- a/katkiss.xml
+++ b/katkiss.xml
@@ -178,4 +178,5 @@
   <remove-project name="device/asus/flo-kernel" />
   <remove-project name="device/htc/flounder-kernel" />
   <remove-project name="platform/prebuilts/android-emulator" />
+  <remove-project name="platform/external/javasqlite" />
    </manifest>


### PR DESCRIPTION
libsqlite_jni is an accidental inclusion by google team, they have removed it in master branch since its not used by anything

Note that before merging this pull request you must first merge these 2 in platform_build:
https://github.com/timduru/platform-build/pull/2
https://github.com/timduru/platform-build/pull/3
