### PR TITLE
Track sqlite from benzorom

### DIFF
--- a/katkiss.xml
+++ b/katkiss.xml
@@ -65,6 +65,10 @@
   <project path="system/vold" name="timduru/platform-system-vold"  revision="katkiss-6.0" remote="github"/>
   <remove-project name="platform/system/bt" />
   <project path="system/bt" name="timduru/platform_system_bt"  revision="katkiss-6.0" remote="github"/>
+  
+  <!-- Track Sqlite from benzorom for the latest security and performance -->
+  <remove-project name="platform/external/sqlite" />
+  <project path="external/sqlite" name="BenzoRom/external_sqlite" remote="gh" revision="marshmallow" />
 
 <!--  <remove-project name="platform/hardware/libhardware" />
   <project path="hardware/libhardware" name="timduru/platform-hardware-libhardware"  revision="katkiss-5.0" remote="github" /> -->


### PR DESCRIPTION
I propose we switch to benzorom's version of sqlite.

Changes:
- Updated from 3.8.6.1 to 3.13
- Enable fdatasync for SQLite ( https://github.com/BenzoRom/external_sqlite/commit/4a3e1ef4cb9e241f2c0458337ffc87d766fa259e )
- enable secure_delete by default ( https://github.com/BenzoRom/external_sqlite/commit/d901d565f693e0a271fa3d428a2a4f0416940cd0 )
- Reduce sync safety levels from 3 to 1 ( https://github.com/BenzoRom/external_sqlite/commit/c3e458f3b9862d4bcad6a096c6304097fddbd021 )

Combined the performance is improved by about 900%, however the secure_delete reduces performance again by 10% of that.
- You can build sqlite3 binary and run the self test to verify there are no issues
- You can run the following benchmarks to verify the performance:
  https://play.google.com/store/apps/details?id=com.redlicense.benchmark.sqlite
  https://play.google.com/store/apps/details?id=com.andromeda.androbench2

These changes have been tested for some time on various devices and seem to work without any regessions (there are actually fixes for android corruption in here somewhere.

Full changelog if you would like to know more, start reading here and go foward using the newer button 
http://www3.sqlite.org/cgi/src/timeline?n=50&a=2014-10-21+21:56:06
